### PR TITLE
use path portion of the URL for unix style URLs

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,14 +87,11 @@ func main() {
 		}
 
 		var address string
-
 		switch strings.ToLower(sockURL.Scheme) {
 		case "udp", "udp4", "udp6", "tcp", "tcp4", "tcp6":
 			address = sockURL.Host;
-
 		case "unix", "unixgram", "unipacket":
 			address = sockURL.Path;
-
 		default:
 			level.Error(logger).Log("socket", *sockAddr, "err", "unsupported network", "network", sockURL.Scheme)
 			os.Exit(1)


### PR DESCRIPTION
Previously the hostname was being used.  So for -socket unix://localhost/tmp/foo.sock it was listening to ./localhost instead of /tmp/foo.sock