### PR TITLE
Add -declpath flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Prometheus metrics aggregator [![Latest Release](https://img.shields.io/github/release/peterbourgon/prometheus-aggregator.svg?style=flat-square)](https://github.com/peterbourgon/prometheus-aggregator/releases/latest) [![Travis CI](https://travis-ci.org/peterbourgon/prometheus-aggregator.svg?branch=master)](https://travis-ci.org/peterbourgon/prometheus-aggregator) 
+# Prometheus metrics aggregator [![Latest Release](https://img.shields.io/github/release/peterbourgon/prometheus-aggregator.svg?style=flat-square)](https://github.com/peterbourgon/prometheus-aggregator/releases/latest) [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fpeterbourgon%2Fprometheus-aggregator%2Fbadge&style=flat-square&label=build)](https://github.com/peterbourgon/prometheus-aggregator/actions?query=workflow%3ATest)
 
 Receive and aggregate metrics for consumption by a Prometheus server.
 
@@ -47,13 +47,14 @@ USAGE
 FLAGS
   -debug false                              log debug information
   -declfile ...                             file containing JSON metric declarations
+  -declpath ...                             sibling path to /metrics serving initial metric declarations
   -example false                            print example declfile to stdout and return
   -prometheus tcp://127.0.0.1:8192/metrics  address for Prometheus scrapes
   -socket tcp://127.0.0.1:8191              address for direct socket metric writes
   -strict false                             disconnect clients when they send bad data
 
 VERSION
-  0.0.12
+  0.0.14
 ```
 
 ## How it works
@@ -91,6 +92,11 @@ You can declare metrics at runtime, like this, or you can predeclare metrics in
 a file containing a JSON array of multiple JSON objects, and pass it to the
 program at startup via the `-declfile` flag. Or mix and match both! Life is
 full of possibility.
+
+New! Exciting! Great Value! An optional `-declpath` flag allows you to serve
+your initial metric declarations on a sibling path to your Prometheus metrics
+telemetry. This can be useful if you want to programmatically verify the state
+of a prometheus-aggregator instance.
 
 ## Prometheus exposition format
 
@@ -131,7 +137,7 @@ Histograms are supported too. Provide buckets with the declaration.
 
 ```
 {"name": "myapp_req_dur_seconds", "type": "histogram",
-  "help": "Duration of request in seconds.", 
+  "help": "Duration of request in seconds.",
     "buckets": [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10]}
 myapp_req_dur_seconds{} 0.0123
 myapp_req_dur_seconds{} 0.99

--- a/universe.go
+++ b/universe.go
@@ -32,7 +32,8 @@ type (
 		values  map[timeseriesKey]timeseriesValue
 	}
 
-	// timeseriesKey is universally unique e.g. `http_requests_total{method="GET",status_code="200"}`.
+	// timeseriesKey is universally unique, e.g.
+	// `http_requests_total{method="GET",status_code="200"}`.
 	timeseriesKey string
 
 	// timeseriesValue is a set of observations for
@@ -192,8 +193,13 @@ type observation struct {
 	Value   *float64          `json:"value,omitempty"`
 }
 
-func (o observation) metricName() metricName       { return metricName(o.Name) }
-func (o observation) timeseriesKey() timeseriesKey { return makeTimeseriesKey(o.Name, o.Labels) }
+func (o observation) metricName() metricName {
+	return metricName(o.Name)
+}
+
+func (o observation) timeseriesKey() timeseriesKey {
+	return makeTimeseriesKey(o.Name, o.Labels)
+}
 
 //
 //
@@ -215,8 +221,13 @@ func newCounter(o observation) (*counter, error) {
 	}, nil
 }
 
-func (c *counter) metricName() metricName       { return metricName(c.n) }
-func (c *counter) timeseriesKey() timeseriesKey { return makeTimeseriesKey(c.n, c.labels) }
+func (c *counter) metricName() metricName {
+	return metricName(c.n)
+}
+
+func (c *counter) timeseriesKey() timeseriesKey {
+	return makeTimeseriesKey(c.n, c.labels)
+}
 
 func (c *counter) observe(o observation) error {
 	if o.Value == nil {
@@ -253,8 +264,13 @@ func newGauge(o observation) (*gauge, error) {
 	}, nil
 }
 
-func (g *gauge) metricName() metricName       { return metricName(g.n) }
-func (g *gauge) timeseriesKey() timeseriesKey { return makeTimeseriesKey(g.n, g.labels) }
+func (g *gauge) metricName() metricName {
+	return metricName(g.n)
+}
+
+func (g *gauge) timeseriesKey() timeseriesKey {
+	return makeTimeseriesKey(g.n, g.labels)
+}
 
 func (g *gauge) observe(o observation) error {
 	if o.Value == nil {
@@ -307,8 +323,13 @@ func newHistogram(o observation) (*histogram, error) {
 	}, nil
 }
 
-func (h *histogram) metricName() metricName       { return metricName(h.n) }
-func (h *histogram) timeseriesKey() timeseriesKey { return makeTimeseriesKey(h.n, h.labels) }
+func (h *histogram) metricName() metricName {
+	return metricName(h.n)
+}
+
+func (h *histogram) timeseriesKey() timeseriesKey {
+	return makeTimeseriesKey(h.n, h.labels)
+}
 
 func (h *histogram) observe(o observation) error {
 	if o.Value == nil {


### PR DESCRIPTION
New! Exciting! Great Value! An optional `-declpath` flag allows you to serve your initial metric declarations on a sibling path to your Prometheus metrics telemetry. This can be useful if you want to programmatically verify the state of a prometheus-aggregator instance.